### PR TITLE
clarify ui-common-library submodule setup

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "ui/ui-common-library"]
 	path = ui/ui-common-library
 	url = git@github.com:Holo-Host/ui-common-library.git
+	branch = clutter-insights

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This will install all the needed dependencies in your local environment, includi
 5. Install git submodule dependency (ui-common-library)
 
 ```bash
+git submodule init
 git submodule update --remote --recursive
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ npm install
 
 This will install all the needed dependencies in your local environment, including `holochain`, `hc` and `npm`.
 
+5. Install git submodule dependency (ui-common-library)
+
+```bash
+git submodule update --remote --recursive
+```
+
 ## Building the DNA
 
 - Build the DNA (assumes you are still in the nix shell for correct rust/cargo versions from step above):


### PR DESCRIPTION
- specify branch 'clutter-insights' for git submodule
- document command to properly install submodule in README