### PR TITLE
feat: support multi-word url tags with format ^[link text]

### DIFF
--- a/ui/src/components/CreateMewField.vue
+++ b/ui/src/components/CreateMewField.vue
@@ -254,9 +254,17 @@ const onLinkTextKeyDown = (keyDownEvent: KeyboardEvent) => {
 
     const anchor = document.createElement("a");
     anchor.href = "#";
-    anchor.textContent = linkText.value
-      ? TAG_SYMBOLS.URL + linkText.value
-      : url;
+
+    // Wrap link text in brackets if it has multiple words
+    const linkTextValue = linkText.value?.trim();
+    if (linkTextValue?.includes(" ")) {
+      anchor.textContent = `${TAG_SYMBOLS.URL}[${linkTextValue}]`;
+    } else if (linkText.value) {
+      anchor.textContent = TAG_SYMBOLS.URL + linkTextValue;
+    } else {
+      anchor.textContent = url;
+    }
+
     anchor.dataset[ANCHOR_DATA_ID_URL] = url ?? undefined;
     range.insertNode(anchor);
     // insert space after link

--- a/ui/src/utils/tags.ts
+++ b/ui/src/utils/tags.ts
@@ -9,6 +9,7 @@ const regexpString = [
   `\\${TAG_SYMBOLS.CASHTAG}\\w+`,
   `\\${TAG_SYMBOLS.HASHTAG}\\w+`,
   `\\${TAG_SYMBOLS.MENTION}\\S+`,
-  `\\${TAG_SYMBOLS.URL}\\S+`,
+  `\\${TAG_SYMBOLS.URL}\\[[\\w ]+\\]`, // multi-word url
+  `\\${TAG_SYMBOLS.URL}\\S+`, // single-word url
 ];
 export const TAG_REGEX = new RegExp(`\\B(${regexpString.join("|")})`, "gi");


### PR DESCRIPTION
This is the lightest-touch implementation of multi-word links I could think of. 

It adds a new link syntax to mew text: links wrapped by brackets can contain spaces in their text. I.e. `^[multi word link]` or `^link` both work.

If desired, we could hide the brackets from the UI, but keep them in the actual mew text data.

Or, an alternative implementation would be to modify the Mew entry type to store the complete structure of its contents. This would make the Mew entry type a bit stricter and more opinionated about what kind of data constitutes a "mew". I.e.

```rust
struct Mew {
  raw_text: String,
  parts: Vec<MewPart>
}
struct MewPart {
  Text(String)
  Hashtag(String)
  Cashtag(String)
  Agent(AgentPubKey)
  ExternalLink(LinkContent)
}
struct LinkContent {
  Text(String)
  Url(String)
}
```